### PR TITLE
Fix for php 5.6

### DIFF
--- a/src/PageElement.php
+++ b/src/PageElement.php
@@ -4,7 +4,7 @@ namespace SystemInc\LaravelAdmin;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Request;
-use SystemInc\LaravelAdmin\Facades\SLA;
+use SystemInc\LaravelAdmin\Facades\SLA as SystemLaravelAdmin;
 
 class PageElement extends Model
 {
@@ -43,7 +43,7 @@ class PageElement extends Model
                 break;
 
             case 3:
-                return SLA::getFile($value);
+                return SystemLaravelAdmin::getFile($value);
                 break;
 
             default:


### PR DESCRIPTION
Cannot use SystemInc\LaravelAdmin\Facades\SLA as SLA because the name is already in use