### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "license": "MIT",
     "minimum-stability": "stable",
-    
+
     "authors": [
         {
             "name": "Mladen Janjetovic",
@@ -39,7 +39,7 @@
         "doctrine/dbal": "^2.5",
         "php": ">=5.6"
     },
-    
+
     "scripts": {
         "post-package-update": [
             "php artisan laravel-admin:update"
@@ -48,7 +48,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.6 || ^5.0",
         "fzaninotto/faker": "^1.6",
-        "mockery/mockery": "^0.9.9",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.4"
     },
     "extra": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).